### PR TITLE
Retains unix_socket on all envs

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,6 @@ DB_HOST=localhost
 DB_DATABASE=l5
 DB_USERNAME=root
 DB_PASSWORD=root
-DB_SOCKET=/Applications/MAMP/tmp/mysql/mysql.sock
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/libs/Config/Database.php
+++ b/libs/Config/Database.php
@@ -5,16 +5,17 @@ use App;
 class Database {
 
 	/**
-	 * If on local environment, DB_SOCKET is an available .env option, if we can find a MAMP socket, that's the default
+	 * If on local environment, if we can find a MAMP socket, that's the default db socket
 	 * @param  array  $array [description]
 	 * @return [type]        [description]
 	 */
 	public static function mySQLconnection( $array ) {
+		$mampSocket = '';
 		if ( env( 'APP_ENV' ) === 'local' ) {
  			$path = '/Applications/MAMP/tmp/mysql/mysql.sock';
- 			$mampSocket = ( file_exists( $path ) ) ? $path : '';
- 			$array['unix_socket'] = env( 'DB_SOCKET', $mampSocket );
+ 			if( file_exists( $path ) ) $mampSocket = $path;
   		}
+  		$array['unix_socket'] = env( 'DB_SOCKET', $mampSocket );
 		return $array;
 	}
 


### PR DESCRIPTION
Also removed `DB_SOCKET` default as it isn't needed
